### PR TITLE
Update dependencies

### DIFF
--- a/client.coffee
+++ b/client.coffee
@@ -1,4 +1,4 @@
-uuid = require('node-uuid')
+uuid = require('uuid')
 signing = require('./signing')
 SubscriptionManager = require('./subscription').SubscriptionManager
 logger = require('./logger').logger

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "TaigaIO-Events",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Taiga project management system (events)",
   "main": "index.js",
   "keywords": [
@@ -16,20 +16,21 @@
     "url": "https://github.com/taigaio/taiga-events.git"
   },
   "devDependencies": {
-    "gulp": "^3.8.11",
-    "gulp-cache": "^0.3.0",
-    "gulp-coffee": "^2.3.3",
-    "gulp-coffeelint": "^0.5.0",
-    "gulp-nodemon": "^2.0.4",
-    "gulp-plumber": "^1.0.1"
+    "gulp": "^4.0.0",
+    "gulp-cache": "^1.1.0",
+    "gulp-coffee": "^3.0.3",
+    "gulp-coffeelint": "^0.6.0",
+    "gulp-nodemon": "^2.4.2",
+    "gulp-plumber": "^1.2.1"
   },
   "dependencies": {
-    "amqplib": "^0.5.1",
-    "base64-url": "^1.2.1",
-    "bluebird": "^2.9.10",
+    "amqplib": "^0.5.3",
+    "base64-url": "^2.2.0",
+    "bluebird": "^3.5.3",
+    "coffeescript": "^2.3.2",
     "minimist": "^1.2.0",
-    "node-uuid": "^1.4.2",
-    "winston": "^3.0.0-rc5",
-    "ws": "^2.0.3"
+    "uuid": "^3.3.2",
+    "winston": "^3.1.0",
+    "ws": "^6.1.2"
   }
 }


### PR DESCRIPTION
Various dependencies were out-of-date, unmaintained, with security issues.

- gulp updated (removes 'deprecated gulp-utils')
- amqlib move to 0.5.3 to get node 11.1
- switch from node-uuid to uuid (node-uuid is not maintained)
- switch to released version of winston from release-candidate

Signed-off-by: Don Bowman <don@agilicus.com>